### PR TITLE
[portsorch]: Move PVID setting for port before adding it to LAG

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2212,6 +2212,12 @@ bool PortsOrch::addLagMember(Port &lag, Port &port)
 {
     SWSS_LOG_ENTER();
 
+    sai_uint32_t pvid;
+    if (getPortPvid(lag, pvid))
+    {
+        setPortPvid (port, pvid);
+    }
+
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
 
@@ -2251,11 +2257,6 @@ bool PortsOrch::addLagMember(Port &lag, Port &port)
                     hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_KEEP], port.m_alias.c_str(), lag.m_alias.c_str());
             return false;
         }
-    }
-    sai_uint32_t pvid;
-    if (getPortPvid(lag, pvid))
-    {
-        setPortPvid (port, pvid);
     }
 
     LagMemberUpdate update = { lag, port, true };


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

**What I did**
Move setting of PVID for the port before adding it to LAG instead of setting PVID after LAG member is already created.
**Why I did it**
Setting PVID on LAG member is not allowed and error is returned from SAI, which causes orchagent crach (abort).
Note: issue is not always reproducible because "setPortPvid" is under "if" condition and in "false" case PVID is not set.
So, to resolve the issue need to set PVID before creating LAG member.
**How I verified it**
Manual test: create LAG and add some port to it.
**Details if related**
